### PR TITLE
Check unmarshal errors

### DIFF
--- a/example/testcasing_jsonenums.go
+++ b/example/testcasing_jsonenums.go
@@ -63,7 +63,7 @@ func (r *TestCasing) UnmarshalJSON(data []byte) error {
 func (r *TestCasing) Scan(i interface{}) error {
 	switch t := i.(type) {
 	case string:
-		r.UnmarshalJSON([]byte(t))
+		return r.UnmarshalJSON([]byte(t))
 	default:
 		return fmt.Errorf("Can't scan %T into type %T", i, r)
 	}

--- a/template.go
+++ b/template.go
@@ -73,7 +73,7 @@ func (r *{{$typename}}) UnmarshalJSON(data []byte) error {
 func (r *{{$typename}}) Scan(i interface{}) error {
 	switch t := i.(type) {
 	case string:
-		r.UnmarshalJSON([]byte(t))
+		return r.UnmarshalJSON([]byte(t))
 	default:
 		return fmt.Errorf("Can't scan %T into type %T", i, r)
 	}


### PR DESCRIPTION
A quick fix to check an unchecked error causing gillnet go tests to fail. 
