### PR TITLE
Add back []byte case

### DIFF
--- a/example/shirtsize_jsonenums.go
+++ b/example/shirtsize_jsonenums.go
@@ -83,6 +83,8 @@ func (r *ShirtSize) UnmarshalJSON(data []byte) error {
 //Scan an input string into this structure for use with GORP
 func (r *ShirtSize) Scan(i interface{}) error {
 	switch t := i.(type) {
+	case []byte:
+		return r.setValue(string(t))
 	case string:
 		return r.setValue(t)
 	default:

--- a/example/weekday_jsonenums.go
+++ b/example/weekday_jsonenums.go
@@ -86,6 +86,8 @@ func (r *WeekDay) UnmarshalJSON(data []byte) error {
 //Scan an input string into this structure for use with GORP
 func (r *WeekDay) Scan(i interface{}) error {
 	switch t := i.(type) {
+	case []byte:
+		return r.setValue(string(t))
 	case string:
 		return r.setValue(t)
 	default:

--- a/template.go
+++ b/template.go
@@ -84,6 +84,8 @@ func (r *{{$typename}}) UnmarshalJSON(data []byte) error {
 //Scan an input string into this structure for use with GORP
 func (r *{{$typename}}) Scan(i interface{}) error {
 	switch t := i.(type) {
+	case []byte:
+		return r.setValue(string(t))
 	case string:
 		return r.setValue(t)
 	default:


### PR DESCRIPTION
Quinten was confused about the []byte and string cases and advised
removing the incorrect one. We do see this come from gorp and do need to
handle this case in scanning.
