### PR TITLE
Define a more specific error for invalid values

### DIFF
--- a/example/customstatus_jsonenums.go
+++ b/example/customstatus_jsonenums.go
@@ -74,7 +74,7 @@ func (r CustomStatus) getString() (string, error) {
 func (r *CustomStatus) setValue(str string) error {
 	v, ok := _CustomStatusNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid CustomStatus %q", str)
+		return _CustomStatusInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -93,7 +93,7 @@ func (r CustomStatus) MarshalJSON() ([]byte, error) {
 func (r *CustomStatus) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("CustomStatus should be a string, got %s", data)
+		return _CustomStatusInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/customstatus_jsonenums.go
+++ b/example/customstatus_jsonenums.go
@@ -24,6 +24,18 @@ var (
 	}
 )
 
+type _CustomStatusInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _CustomStatusInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid CustomStatus: %s", e.invalidValue)
+}
+
+func (e _CustomStatusInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v CustomStatus
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/example/customstatus_jsonenums.go
+++ b/example/customstatus_jsonenums.go
@@ -36,6 +36,14 @@ func init() {
 	}
 }
 
+func ListCustomStatusValues() map[string]string {
+	CustomStatusList := make(map[string]string)
+	for k := range _CustomStatusNameToValue {
+		CustomStatusList[k] = k
+	}
+	return CustomStatusList
+}
+
 func (r CustomStatus) toString() (string, error) {
 	s, ok := _CustomStatusValueToName[r]
 	if !ok {
@@ -86,9 +94,8 @@ func (r *CustomStatus) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r CustomStatus) Value() (driver.Value, error) {

--- a/example/shirtsize_jsonenums.go
+++ b/example/shirtsize_jsonenums.go
@@ -80,7 +80,7 @@ func (r ShirtSize) getString() (string, error) {
 func (r *ShirtSize) setValue(str string) error {
 	v, ok := _ShirtSizeNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid ShirtSize %q", str)
+		return _ShirtSizeInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -99,7 +99,7 @@ func (r ShirtSize) MarshalJSON() ([]byte, error) {
 func (r *ShirtSize) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("ShirtSize should be a string, got %s", data)
+		return _ShirtSizeInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/shirtsize_jsonenums.go
+++ b/example/shirtsize_jsonenums.go
@@ -28,6 +28,18 @@ var (
 	}
 )
 
+type _ShirtSizeInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _ShirtSizeInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid ShirtSize: %s", e.invalidValue)
+}
+
+func (e _ShirtSizeInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v ShirtSize
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/example/shirtsize_jsonenums.go
+++ b/example/shirtsize_jsonenums.go
@@ -42,6 +42,14 @@ func init() {
 	}
 }
 
+func ListShirtSizeValues() map[string]string {
+	ShirtSizeList := make(map[string]string)
+	for k := range _ShirtSizeNameToValue {
+		ShirtSizeList[k] = k
+	}
+	return ShirtSizeList
+}
+
 func (r ShirtSize) toString() (string, error) {
 	s, ok := _ShirtSizeValueToName[r]
 	if !ok {
@@ -92,9 +100,8 @@ func (r *ShirtSize) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r ShirtSize) Value() (driver.Value, error) {

--- a/example/testallcaps_jsonenums.go
+++ b/example/testallcaps_jsonenums.go
@@ -33,6 +33,14 @@ func init() {
 	}
 }
 
+func ListTestAllCapsValues() map[string]string {
+	TestAllCapsList := make(map[string]string)
+	for k := range _TestAllCapsNameToValue {
+		TestAllCapsList[k] = k
+	}
+	return TestAllCapsList
+}
+
 func (r TestAllCaps) toString() (string, error) {
 	s, ok := _TestAllCapsValueToName[r]
 	if !ok {
@@ -83,9 +91,8 @@ func (r *TestAllCaps) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r TestAllCaps) Value() (driver.Value, error) {

--- a/example/testallcaps_jsonenums.go
+++ b/example/testallcaps_jsonenums.go
@@ -71,7 +71,7 @@ func (r TestAllCaps) getString() (string, error) {
 func (r *TestAllCaps) setValue(str string) error {
 	v, ok := _TestAllCapsNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid TestAllCaps %q", str)
+		return _TestAllCapsInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -90,7 +90,7 @@ func (r TestAllCaps) MarshalJSON() ([]byte, error) {
 func (r *TestAllCaps) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("TestAllCaps should be a string, got %s", data)
+		return _TestAllCapsInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/testallcaps_jsonenums.go
+++ b/example/testallcaps_jsonenums.go
@@ -22,6 +22,18 @@ var (
 	}
 )
 
+type _TestAllCapsInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _TestAllCapsInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid TestAllCaps: %s", e.invalidValue)
+}
+
+func (e _TestAllCapsInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v TestAllCaps
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/example/testcasing_jsonenums.go
+++ b/example/testcasing_jsonenums.go
@@ -71,7 +71,7 @@ func (r TestCasing) getString() (string, error) {
 func (r *TestCasing) setValue(str string) error {
 	v, ok := _TestCasingNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid TestCasing %q", str)
+		return _TestCasingInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -90,7 +90,7 @@ func (r TestCasing) MarshalJSON() ([]byte, error) {
 func (r *TestCasing) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("TestCasing should be a string, got %s", data)
+		return _TestCasingInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/testcasing_jsonenums.go
+++ b/example/testcasing_jsonenums.go
@@ -22,6 +22,18 @@ var (
 	}
 )
 
+type _TestCasingInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _TestCasingInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid TestCasing: %s", e.invalidValue)
+}
+
+func (e _TestCasingInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v TestCasing
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/example/testcasing_jsonenums.go
+++ b/example/testcasing_jsonenums.go
@@ -33,6 +33,14 @@ func init() {
 	}
 }
 
+func ListTestCasingValues() map[string]string {
+	TestCasingList := make(map[string]string)
+	for k := range _TestCasingNameToValue {
+		TestCasingList[k] = k
+	}
+	return TestCasingList
+}
+
 func (r TestCasing) toString() (string, error) {
 	s, ok := _TestCasingValueToName[r]
 	if !ok {
@@ -83,9 +91,8 @@ func (r *TestCasing) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r TestCasing) Value() (driver.Value, error) {

--- a/example/testprefixdrop_jsonenums.go
+++ b/example/testprefixdrop_jsonenums.go
@@ -33,6 +33,14 @@ func init() {
 	}
 }
 
+func ListTestPrefixDropValues() map[string]string {
+	TestPrefixDropList := make(map[string]string)
+	for k := range _TestPrefixDropNameToValue {
+		TestPrefixDropList[k] = k
+	}
+	return TestPrefixDropList
+}
+
 func (r TestPrefixDrop) toString() (string, error) {
 	s, ok := _TestPrefixDropValueToName[r]
 	if !ok {
@@ -83,9 +91,8 @@ func (r *TestPrefixDrop) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r TestPrefixDrop) Value() (driver.Value, error) {

--- a/example/testprefixdrop_jsonenums.go
+++ b/example/testprefixdrop_jsonenums.go
@@ -22,6 +22,18 @@ var (
 	}
 )
 
+type _TestPrefixDropInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _TestPrefixDropInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid TestPrefixDrop: %s", e.invalidValue)
+}
+
+func (e _TestPrefixDropInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v TestPrefixDrop
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/example/testprefixdrop_jsonenums.go
+++ b/example/testprefixdrop_jsonenums.go
@@ -71,7 +71,7 @@ func (r TestPrefixDrop) getString() (string, error) {
 func (r *TestPrefixDrop) setValue(str string) error {
 	v, ok := _TestPrefixDropNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid TestPrefixDrop %q", str)
+		return _TestPrefixDropInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -90,7 +90,7 @@ func (r TestPrefixDrop) MarshalJSON() ([]byte, error) {
 func (r *TestPrefixDrop) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("TestPrefixDrop should be a string, got %s", data)
+		return _TestPrefixDropInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/tostring_jsonenums.go
+++ b/example/tostring_jsonenums.go
@@ -33,6 +33,14 @@ func init() {
 	}
 }
 
+func ListtoStringValues() map[string]string {
+	toStringList := make(map[string]string)
+	for k := range _toStringNameToValue {
+		toStringList[k] = k
+	}
+	return toStringList
+}
+
 func (r toString) toString() (string, error) {
 	s, ok := _toStringValueToName[r]
 	if !ok {
@@ -87,9 +95,8 @@ func (r *toString) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r toString) Value() (driver.Value, error) {

--- a/example/tostring_jsonenums.go
+++ b/example/tostring_jsonenums.go
@@ -75,7 +75,7 @@ func (r toString) getString() (string, error) {
 func (r *toString) setValue(str string) error {
 	v, ok := _toStringNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid toString %q", str)
+		return _toStringInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -94,7 +94,7 @@ func (r toString) MarshalJSON() ([]byte, error) {
 func (r *toString) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("toString should be a string, got %s", data)
+		return _toStringInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/tostring_jsonenums.go
+++ b/example/tostring_jsonenums.go
@@ -22,6 +22,18 @@ var (
 	}
 )
 
+type _toStringInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _toStringInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid toString: %s", e.invalidValue)
+}
+
+func (e _toStringInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v toString
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/example/weekday_jsonenums.go
+++ b/example/weekday_jsonenums.go
@@ -45,6 +45,14 @@ func init() {
 	}
 }
 
+func ListWeekDayValues() map[string]string {
+	WeekDayList := make(map[string]string)
+	for k := range _WeekDayNameToValue {
+		WeekDayList[k] = k
+	}
+	return WeekDayList
+}
+
 func (r WeekDay) toString() (string, error) {
 	s, ok := _WeekDayValueToName[r]
 	if !ok {
@@ -95,9 +103,8 @@ func (r *WeekDay) Scan(i interface{}) error {
 	case string:
 		return r.setValue(t)
 	default:
-		return fmt.Errorf("Can't scan %T into type %T", i, r)
+		return fmt.Errorf("can't scan %T into type %T", i, r)
 	}
-	return nil
 }
 
 func (r WeekDay) Value() (driver.Value, error) {

--- a/example/weekday_jsonenums.go
+++ b/example/weekday_jsonenums.go
@@ -83,7 +83,7 @@ func (r WeekDay) getString() (string, error) {
 func (r *WeekDay) setValue(str string) error {
 	v, ok := _WeekDayNameToValue[str]
 	if !ok {
-		return fmt.Errorf("invalid WeekDay %q", str)
+		return _WeekDayInvalidValueError{invalidValue: str}
 	}
 	*r = v
 	return nil
@@ -102,7 +102,7 @@ func (r WeekDay) MarshalJSON() ([]byte, error) {
 func (r *WeekDay) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("WeekDay should be a string, got %s", data)
+		return _WeekDayInvalidValueError{invalidValue: string(data)}
 	}
 	return r.setValue(s)
 }

--- a/example/weekday_jsonenums.go
+++ b/example/weekday_jsonenums.go
@@ -30,6 +30,18 @@ var (
 	}
 )
 
+type _WeekDayInvalidValueError struct {
+	invalidValue string
+}
+
+func (e _WeekDayInvalidValueError) Error() string {
+	return fmt.Sprintf("invalid WeekDay: %s", e.invalidValue)
+}
+
+func (e _WeekDayInvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
 	var v WeekDay
 	if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/template.go
+++ b/template.go
@@ -33,6 +33,18 @@ var (
     }
 )
 
+type _{{$typename}}InvalidValueError struct {
+	invalidValue string
+}
+
+func (e _{{$typename}}InvalidValueError) Error() string {
+	return fmt.Sprintf("invalid {{$typename}}: %s", e.invalidValue)
+}
+
+func (e _{{$typename}}InvalidValueError) InvalidValueError() string {
+	return e.Error()
+}
+
 func init() {
     var v {{$typename}}
     if _, ok := interface{}(v).(fmt.Stringer); ok {

--- a/template.go
+++ b/template.go
@@ -87,7 +87,7 @@ func (r {{$typename}}) getString() (string, error) {
 func (r *{{$typename}}) setValue(str string) error {
     v, ok := _{{$typename}}NameToValue[str]
     if !ok {
-        return fmt.Errorf("invalid {{$typename}} %q", str)
+        return _{{$typename}}InvalidValueError{invalidValue: str}
     }
     *r = v
     return nil
@@ -106,7 +106,7 @@ func (r {{$typename}}) MarshalJSON() ([]byte, error) {
 func (r *{{$typename}}) UnmarshalJSON(data []byte) error {
     var s string
     if err := json.Unmarshal(data, &s); err != nil {
-        return fmt.Errorf("{{$typename}} should be a string, got %s", data)
+        return _{{$typename}}InvalidValueError{invalidValue: string(data)}
     }
     return r.setValue(s)
 }


### PR DESCRIPTION
Clients can leverage this error to distinguish invalid values from other unexpected errors. Clients detect the new type of error by checking if an error returned from a jsonenums-generated type satisfies an interface that provides `InvalidValueError() string`.