### PR TITLE
MAIN-36416: fix jsonenums

### DIFF
--- a/jsonenums.go
+++ b/jsonenums.go
@@ -78,7 +78,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/campoy/jsonenums/parser"
+	"github.com/clyphub/jsonenums/parser"
 )
 
 var (

--- a/jsonenums.go
+++ b/jsonenums.go
@@ -125,20 +125,7 @@ func main() {
 	}
 	types := strings.Split(*typeNames, ",")
 
-	// Only one directory at a time can be processed, and the default is ".".
-	dir := "."
-	if args := flag.Args(); len(args) == 1 {
-		dir = args[0]
-	} else if len(args) > 1 {
-		log.Fatalf("only one directory at a time")
-	}
-	dir, err := filepath.Abs(dir)
-	if err != nil {
-		log.Fatalf("unable to determine absolute filepath for requested path %s: %v",
-			dir, err)
-	}
-
-	pkg, err := parser.ParsePackage(dir)
+	pkg, err := parser.ParsePackage(flag.Args())
 	if err != nil {
 		log.Fatalf("parsing package: %v", err)
 	}
@@ -207,9 +194,13 @@ func main() {
 			src = buf.Bytes()
 		}
 
+		goPath, exists := os.LookupEnv("GOPATH")
+		if !exists {
+			log.Fatalf("$GOPATH must be set")
+		}
 		output := strings.ToLower(*outputPrefix + typeName +
 			*outputSuffix + ".go")
-		outputPath := filepath.Join(dir, output)
+		outputPath := filepath.Join(goPath, "src", pkg.Path, output)
 		if err := ioutil.WriteFile(outputPath, src, 0644); err != nil {
 			log.Fatalf("writing output: %s", err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 
 	"go/format"
 
-	"github.com/campoy/jsonenums/parser"
+	"github.com/clyphub/jsonenums/parser"
 )
 
 func init() {


### PR DESCRIPTION
This fixes the problem where jsonenums has to be used with the same version of Go it was compiled with.

https://clypdinc.atlassian.net/browse/MAIN-36416