### PR TITLE
CLYPD-41195 - Allow skipping generation of CSV methods

### DIFF
--- a/jsonenums.go
+++ b/jsonenums.go
@@ -89,6 +89,7 @@ var (
 	serializedPrefixToDrop = flag.String("prefix_to_drop", "", "string to drop from beginning of each iota const name when converting to string")
 	allCaps                = flag.Bool("all_caps", false, "convert the serialized string to uppercase?")
 	generateStringer       = flag.Bool("to_string", false, "generating ToString() function for iota?")
+	excludeCSVMethods      = flag.Bool("exclude_csv_methods", false, "skip generating MarshalCSV and UnmarshalCSV?")
 )
 
 func ToSnake(in string) string {
@@ -132,11 +133,13 @@ func main() {
 
 	var analysis = struct {
 		Command        string
+		ExcludeCSV     bool
 		PackageName    string
 		Stringer       bool
 		TypesAndValues map[string][]CammelSnakePair
 	}{
 		Command:        strings.Join(os.Args[1:], " "),
+		ExcludeCSV:     *excludeCSVMethods,
 		PackageName:    pkg.Name,
 		Stringer:       *generateStringer,
 		TypesAndValues: make(map[string][]CammelSnakePair),

--- a/template.go
+++ b/template.go
@@ -127,6 +127,7 @@ func (r {{$typename}}) Value() (driver.Value, error) {
 	return r.getString()
 }
 
+{{if not $.ExcludeCSV}}
 // MarshalCSV is generated so {{$typename}} satisfies csv.Marshaler.
 func (r {{$typename}}) MarshalCSV() (string, error) {
     return r.getString()
@@ -136,6 +137,7 @@ func (r {{$typename}}) MarshalCSV() (string, error) {
 func (r *{{$typename}}) UnmarshalCSV(s string) (error) {
     return r.setValue(s)
 }
+{{end}}
 
 {{end}}
 


### PR DESCRIPTION
Some enums in gillnet have non-standard CSV Marshal/Unmarshall methods. This option allows us to keep those non-standard™ methods around and still be able to `go generate` our entire codebase. See this [discussion](https://github.com/clyphub/gillnet/pull/12536#discussion_r511946859) for more details.

Tested by a building a new binary with these changes locally, then generating code for a simple enum with/without the flag.

Without CSV methods:
```
// generated by jsonenums -type=AdvancedTargetOrigin -prefix_to_drop=AdvancedTargetOrigin -exclude_csv_methods -all_caps -snake_case_json --to_string; DO NOT EDIT

package main

import (
	"database/sql/driver"
	"encoding/json"
	"fmt"
)

var (
	_AdvancedTargetOriginNameToValue = map[string]AdvancedTargetOrigin{
		"NMI": AdvancedTargetOriginNMI,
	}

	_AdvancedTargetOriginValueToName = map[AdvancedTargetOrigin]string{
		AdvancedTargetOriginNMI: "NMI",
	}
)

type _AdvancedTargetOriginInvalidValueError struct {
	invalidValue string
}

func (e _AdvancedTargetOriginInvalidValueError) Error() string {
	return fmt.Sprintf("invalid AdvancedTargetOrigin: %s", e.invalidValue)
}

func (e _AdvancedTargetOriginInvalidValueError) InvalidValueError() string {
	return e.Error()
}

func init() {
	var v AdvancedTargetOrigin
	if _, ok := interface{}(v).(fmt.Stringer); ok {
		_AdvancedTargetOriginNameToValue = map[string]AdvancedTargetOrigin{
			interface{}(AdvancedTargetOriginNMI).(fmt.Stringer).String(): AdvancedTargetOriginNMI,
		}
	}
}

func ListAdvancedTargetOriginValues() map[string]string {
	AdvancedTargetOriginList := make(map[string]string)
	for k := range _AdvancedTargetOriginNameToValue {
		AdvancedTargetOriginList[k] = k
	}
	return AdvancedTargetOriginList
}

func (r AdvancedTargetOrigin) toString() (string, error) {
	s, ok := _AdvancedTargetOriginValueToName[r]
	if !ok {
		return "", fmt.Errorf("invalid AdvancedTargetOrigin: %d", r)
	}
	return s, nil
}

func (r AdvancedTargetOrigin) ToString() (string, error) {
	return r.toString()
}

func (r AdvancedTargetOrigin) getString() (string, error) {
	if s, ok := interface{}(r).(fmt.Stringer); ok {
		return s.String(), nil
	}
	return r.toString()
}

func (r *AdvancedTargetOrigin) setValue(str string) error {
	v, ok := _AdvancedTargetOriginNameToValue[str]
	if !ok {
		return _AdvancedTargetOriginInvalidValueError{invalidValue: str}
	}
	*r = v
	return nil
}

// MarshalJSON is generated so AdvancedTargetOrigin satisfies json.Marshaler.
func (r AdvancedTargetOrigin) MarshalJSON() ([]byte, error) {
	s, err := r.getString()
	if err != nil {
		return nil, err
	}
	return json.Marshal(s)
}

// UnmarshalJSON is generated so AdvancedTargetOrigin satisfies json.Unmarshaler.
func (r *AdvancedTargetOrigin) UnmarshalJSON(data []byte) error {
	var s string
	if err := json.Unmarshal(data, &s); err != nil {
		return _AdvancedTargetOriginInvalidValueError{invalidValue: string(data)}
	}
	return r.setValue(s)
}

//Scan an input string into this structure for use with GORP
func (r *AdvancedTargetOrigin) Scan(i interface{}) error {
	switch t := i.(type) {
	case []byte:
		return r.setValue(string(t))
	case string:
		return r.setValue(t)
	default:
		return fmt.Errorf("can't scan %T into type %T", i, r)
	}
}

func (r AdvancedTargetOrigin) Value() (driver.Value, error) {
	return r.getString()
}
```

With CSV Methods:
```
// generated by jsonenums -type=AdvancedTargetOrigin -prefix_to_drop=AdvancedTargetOrigin -all_caps -snake_case_json --to_string; DO NOT EDIT

package main

import (
	"database/sql/driver"
	"encoding/json"
	"fmt"
)

var (
	_AdvancedTargetOriginNameToValue = map[string]AdvancedTargetOrigin{
		"NMI": AdvancedTargetOriginNMI,
	}

	_AdvancedTargetOriginValueToName = map[AdvancedTargetOrigin]string{
		AdvancedTargetOriginNMI: "NMI",
	}
)

type _AdvancedTargetOriginInvalidValueError struct {
	invalidValue string
}

func (e _AdvancedTargetOriginInvalidValueError) Error() string {
	return fmt.Sprintf("invalid AdvancedTargetOrigin: %s", e.invalidValue)
}

func (e _AdvancedTargetOriginInvalidValueError) InvalidValueError() string {
	return e.Error()
}

func init() {
	var v AdvancedTargetOrigin
	if _, ok := interface{}(v).(fmt.Stringer); ok {
		_AdvancedTargetOriginNameToValue = map[string]AdvancedTargetOrigin{
			interface{}(AdvancedTargetOriginNMI).(fmt.Stringer).String(): AdvancedTargetOriginNMI,
		}
	}
}

func ListAdvancedTargetOriginValues() map[string]string {
	AdvancedTargetOriginList := make(map[string]string)
	for k := range _AdvancedTargetOriginNameToValue {
		AdvancedTargetOriginList[k] = k
	}
	return AdvancedTargetOriginList
}

func (r AdvancedTargetOrigin) toString() (string, error) {
	s, ok := _AdvancedTargetOriginValueToName[r]
	if !ok {
		return "", fmt.Errorf("invalid AdvancedTargetOrigin: %d", r)
	}
	return s, nil
}

func (r AdvancedTargetOrigin) ToString() (string, error) {
	return r.toString()
}

func (r AdvancedTargetOrigin) getString() (string, error) {
	if s, ok := interface{}(r).(fmt.Stringer); ok {
		return s.String(), nil
	}
	return r.toString()
}

func (r *AdvancedTargetOrigin) setValue(str string) error {
	v, ok := _AdvancedTargetOriginNameToValue[str]
	if !ok {
		return _AdvancedTargetOriginInvalidValueError{invalidValue: str}
	}
	*r = v
	return nil
}

// MarshalJSON is generated so AdvancedTargetOrigin satisfies json.Marshaler.
func (r AdvancedTargetOrigin) MarshalJSON() ([]byte, error) {
	s, err := r.getString()
	if err != nil {
		return nil, err
	}
	return json.Marshal(s)
}

// UnmarshalJSON is generated so AdvancedTargetOrigin satisfies json.Unmarshaler.
func (r *AdvancedTargetOrigin) UnmarshalJSON(data []byte) error {
	var s string
	if err := json.Unmarshal(data, &s); err != nil {
		return _AdvancedTargetOriginInvalidValueError{invalidValue: string(data)}
	}
	return r.setValue(s)
}

//Scan an input string into this structure for use with GORP
func (r *AdvancedTargetOrigin) Scan(i interface{}) error {
	switch t := i.(type) {
	case []byte:
		return r.setValue(string(t))
	case string:
		return r.setValue(t)
	default:
		return fmt.Errorf("can't scan %T into type %T", i, r)
	}
}

func (r AdvancedTargetOrigin) Value() (driver.Value, error) {
	return r.getString()
}

// MarshalCSV is generated so AdvancedTargetOrigin satisfies csv.Marshaler.
func (r AdvancedTargetOrigin) MarshalCSV() (string, error) {
	return r.getString()
}

// UnmarshalCSV is generated so AdvancedTargetOrigin satisfies csv.Unmarshaler.
func (r *AdvancedTargetOrigin) UnmarshalCSV(s string) error {
	return r.setValue(s)
}

```